### PR TITLE
iOSでブラウザを見た時エラーが起こる対処

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -14,4 +14,5 @@
 .gitignore
 
 node_modules
+.secret
 #!include:.gitignore

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ app.post("/ask-gemini", async (req, res) => {
         res.set("Access-Control-Allow-Origin", "*");
         res.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
         res.set("Access-Control-Allow-Headers", "Content-Type");
+        res.set("Content-Type", "application/json");
 
         res.json(response);
     } catch (error) {


### PR DESCRIPTION
- Add explicit Content-Type header for JSON responses
- Update .gcloudignore to exclude .secret file